### PR TITLE
FT2-239: Added RGB field API task.

### DIFF
--- a/web/modules/custom/rgb_field/config/schema/rgb_field.schema.yml
+++ b/web/modules/custom/rgb_field/config/schema/rgb_field.schema.yml
@@ -1,0 +1,7 @@
+field.value.rgb_field_rgb_field:
+  type: mapping
+  label: Default value
+  mapping:
+    value:
+      type: label
+      label: Value

--- a/web/modules/custom/rgb_field/rgb_field.info.yml
+++ b/web/modules/custom/rgb_field/rgb_field.info.yml
@@ -1,0 +1,5 @@
+name: 'rgb_field'
+type: module
+description: 'Custom RGB field'
+package: Custom
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/rgb_field/rgb_field.module
+++ b/web/modules/custom/rgb_field/rgb_field.module
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Drupal\Core\Access\AccessResult;
+
+/**
+ * Implements hook_entity_field_access().
+ */
+function rgb_field_entity_field_access($operation, $field_definition) {
+  // Check if the field is our custom field.
+  if ($field_definition->getName() === 'field_rgb') {
+    // Only allow admin users to view or edit the field.
+    $roles = \Drupal::currentUser()->getRoles();
+    if ($operation === 'view') {
+      // Check if the user is an administrator.
+      if (in_array('administrator', $roles)) {
+        return AccessResult::allowed();
+      }
+      else {
+        return AccessResult::forbidden();
+      }
+    }
+  }
+
+  // Return neutral access result for other fields.
+  return AccessResult::neutral();
+}

--- a/web/modules/custom/rgb_field/src/Plugin/Field/FieldFormatter/RgbFieldFormatter.php
+++ b/web/modules/custom/rgb_field/src/Plugin/Field/FieldFormatter/RgbFieldFormatter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\rgb_field\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'rgb_field' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "rgb_field_rgb_field",
+ *   label = @Translation("rgb_field"),
+ *   field_types = {"rgb_field_rgb_field"},
+ * )
+ */
+final class RgbFieldFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $element = [];
+
+    foreach ($items as $delta => $item) {
+      // Get the RGB values
+      $r = $item->red ?? 0;
+      $g = $item->green ?? 0;
+      $b = $item->blue ?? 0;
+
+      // Create the RGB string
+      $rgb_value = "rgb($r, $g, $b)";
+
+      // Render the color box
+      $element[$delta] = [
+        '#markup' => t('<div style="height:200px;width:200px; background-color:@rgb_value;border-radius:50%;display:flex;align-items:center;justify-content:center;">@msg</div>', ['@rgb_value' => $rgb_value
+      ,'@msg'=>'Hi There']),
+      ];
+    }
+    return $element;
+  }
+}

--- a/web/modules/custom/rgb_field/src/Plugin/Field/FieldType/RgbFieldItem.php
+++ b/web/modules/custom/rgb_field/src/Plugin/Field/FieldType/RgbFieldItem.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\rgb_field\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Defines the 'rgb_field_rgb_field' field type.
+ *
+ * @FieldType(
+ *   id = "rgb_field_rgb_field",
+ *   label = @Translation("rgb_field"),
+ *   description = @Translation("Some description."),
+ *   default_widget = "customfield_hexcolor",
+ *   default_formatter = "rgb_field_rgb_field",
+ * )
+ */
+final class RgbFieldItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition): array {
+
+    // @DCG
+    // See /core/lib/Drupal/Core/TypedData/Plugin/DataType directory for
+    // available data types.
+    $properties['red'] = DataDefinition::create('integer')
+      ->setLabel(t('Red'))
+      ->addConstraint('Range', ['min' => 0, 'max' => 255])
+      ->setRequired(TRUE);
+
+    $properties['green'] = DataDefinition::create('integer')
+      ->setLabel(t('Green'))
+      ->addConstraint('Range', ['min' => 0, 'max' => 255])
+      ->setRequired(TRUE);
+
+    $properties['blue'] = DataDefinition::create('integer')
+      ->setLabel(t('Blue'))
+      ->addConstraint('Range', ['min' => 0, 'max' => 255])
+      ->setRequired(TRUE);
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition): array {
+
+    $columns = [
+      'red' => [
+        'type' => 'int',
+        'not null' => FALSE,
+        'description' => 'Red color.',
+        'min' => 0,
+        'max' => 255
+      ],
+      'green' => [
+        'type' => 'int',
+        'not null' => FALSE,
+        'description' => 'Green color.',
+        'min' => 0,
+        'max' => 255
+      ],
+      'blue' => [
+        'type' => 'int',
+        'not null' => FALSE,
+        'description' => 'Blue color.',
+        'min' => 0,
+        'max' => 255
+      ],
+    ];
+
+    $schema = [
+      'columns' => $columns,
+    ];
+
+    return $schema;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function generateSampleValue(FieldDefinitionInterface $field_definition): array {
+    $values['red'] = mt_rand(0, 255);
+    $values['green'] = mt_rand(0, 255);
+    $values['blue'] = mt_rand(0, 255);
+    return $values;
+  }
+}

--- a/web/modules/custom/rgb_field/src/Plugin/Field/FieldWidget/ColorpickerWidget.php
+++ b/web/modules/custom/rgb_field/src/Plugin/Field/FieldWidget/ColorpickerWidget.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\rgb_field\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\Color;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines the 'customfield_colorpicker' field widget.
+ *
+ * @FieldWidget(
+ *   id = "customfield_colorpicker",
+ *   label = @Translation("colorpicker"),
+ *   field_types = {"rgb_field_rgb_field"},
+ * )
+ */
+final class ColorpickerWidget extends WidgetBase {
+
+  public function formElement(FieldItemListInterface $items, $delta, array $element,
+   array &$form,FormStateInterface $form_state): array{
+    // Get the RGB values from the items.
+    $red = $items[$delta]->red ?? 0;
+    $green = $items[$delta]->green ?? 0;
+    $blue = $items[$delta]->blue ?? 0;
+
+    // Convert RGB values to hex.
+    $hex = sprintf('#%02x%02x%02x', $red, $green, $blue);
+
+    // Add the color picker field to the form.
+    $element['color'] = [
+      '#type' => 'color',
+      '#title' => $this->t('Color Picker'),
+      '#default_value' => $hex,
+      '#description' => $this->t('Select a color using the color picker.'),
+      '#required' => TRUE,
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form,
+   FormStateInterface $form_state): array {
+    foreach ($values as &$value) {
+      if (isset($value['color']) && $this->validateHexCode($value['color'])) {
+        $rgb = Color::hexToRgb($value['color']);
+        $value['red'] = $rgb['red'] ?? 0;
+        $value['green'] = $rgb['green'] ?? 0;
+        $value['blue'] = $rgb['blue'] ?? 0;
+      }
+      else {
+        $value['red'] = $value['green'] = $value['blue'] = NULL;
+      }
+    }
+    return $values;
+  }
+
+  /**
+   * Function to validate Hex codes.
+   *
+   * @param string $hex
+   *   Hex code.
+   *
+   * @return boolean
+   */
+  private function validateHexCode(string $hex): bool {
+    return preg_match('/^#[0-9A-Fa-f]{6}$/', $hex) === 1;
+  }
+}

--- a/web/modules/custom/rgb_field/src/Plugin/Field/FieldWidget/HexWidget.php
+++ b/web/modules/custom/rgb_field/src/Plugin/Field/FieldWidget/HexWidget.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\rgb_field\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\Color;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines the 'customfield_hexcolor' field widget.
+ *
+ * @FieldWidget(
+ *   id = "customfield_hexcolor",
+ *   label = @Translation("Hex color"),
+ *   field_types = {"rgb_field_rgb_field"},
+ * )
+ */
+final class HexWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta,
+   array $element, array &$form, FormStateInterface $form_state): array{
+    // Get the RGB values from the items.
+    $red = $items[$delta]->red ?? NULL;
+    $green = $items[$delta]->green ?? NULL;
+    $blue = $items[$delta]->blue ?? NULL;
+    // Convert RGB values to hex.
+    $hex = ($red !== NULL && $green !== NULL && $blue !== NULL) ? sprintf('#%02x%02x%02x', $red, $green, $blue) : '';
+    // Add the hex field to the form.
+    $element['hex'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Hex color'),
+      '#default_value' => $hex,
+      '#description' => $this->t('Enter the color in hex format (#RRGGBB).'),
+      '#required' => TRUE,
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form,
+   FormStateInterface $form_state): array {
+    foreach ($values as &$value) {
+      // Validate and convert hex code to RGB using Drupal's Color utility.
+      if (isset($value['hex']) && $this->validateHexCode($value['hex'])) {
+        $rgb = Color::hexToRgb($value['hex']);
+        $value['red'] = $rgb['red'] ?? 0;
+        $value['green'] = $rgb['green'] ?? 0;
+        $value['blue'] = $rgb['blue'] ?? 0;
+      }
+      else {
+        // Handle invalid hex code if necessary.
+        $value['red'] = $value['green'] = $value['blue'] = NULL;
+      }
+    }
+
+    return $values;
+  }
+
+  /**
+   * Function to validate Hex codes.
+   *
+   * @param string $hex
+   *   Hex code.
+   *
+   * @return boolean
+   */
+  private function validateHexCode(string $hex): bool {
+    return preg_match('/^#[0-9A-Fa-f]{6}$/', $hex) === 1;
+  }
+}

--- a/web/modules/custom/rgb_field/src/Plugin/Field/FieldWidget/RgbFieldWidget.php
+++ b/web/modules/custom/rgb_field/src/Plugin/Field/FieldWidget/RgbFieldWidget.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\rgb_field\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines the 'rgb_field_rgb_field' field widget.
+ *
+ * @FieldWidget(
+ *   id = "rgb_field_rgb_field",
+ *   label = @Translation("rgb_field"),
+ *   field_types = {"rgb_field_rgb_field"},
+ * )
+ */
+final class RgbFieldWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element,
+  array &$form, FormStateInterface $form_state): array {
+    // Get the RGB values from the items.
+    $red = $items[$delta]->red ?? NULL;
+    $green = $items[$delta]->green ?? NULL;
+    $blue = $items[$delta]->blue ?? NULL;
+    
+    // Add the rgb field to the form.
+    $element['red'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Red'),
+      '#default_value' => $red,
+    ];
+    $element['green'] =  [
+      '#type' => 'number',
+      '#title' => $this->t('Green'),
+      '#default_value' => $green,
+    ];
+    $element['blue'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Blue'),
+      '#default_value' => $blue,
+    ];
+    return $element;
+  }
+}


### PR DESCRIPTION
1. Created a custom field type to accept RGB color.
- Accept the 6-digit hex code.
- Display 3 different fields to accept code for R, G and B
- Color Picker
2. Display a static text of the color code accepted by the user.
3. Add field permission so that the field is only shown to admin.